### PR TITLE
OY-5282 koodisot ja relaatiotaulut luetaan aina kokonaan

### DIFF
--- a/dbt/models/dw/yleiskayttoiset/dw_koodisto_koodi.sql
+++ b/dbt/models/dw/yleiskayttoiset/dw_koodisto_koodi.sql
@@ -1,27 +1,14 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'merge',
-    unique_key = 'koodi_id',
-    merge_exclude_columns = [
-            'dw_metadata_dbt_copied_at',
-            'dw_metadata_file_row_number',
-            'dw_metadata_filename',
-            'dw_metadata_source_timestamp_at',
-            'dw_metadata_dw_stored_at'
-            ],
+    materialized = 'table',
     indexes = [
         {'columns': ['koodistouri']},
-        {'columns': ['muokattu']}
     ]
     )
 }}
 
 with raw as (
     select * from {{ ref('stg_koodisto_koodi') }}
-    {% if is_incremental() %}
-        where muokattu > (select coalesce(max(t.muokattu), date('1900-01-01')) from {{ this }} as t)
-    {% endif %}
 ),
 
 final as (
@@ -30,6 +17,5 @@ final as (
         current_timestamp as dw_metadata_dw_stored_at
     from raw
 )
-
 
 select * from final

--- a/dbt/models/dw/yleiskayttoiset/dw_koodisto_relaatio.sql
+++ b/dbt/models/dw/yleiskayttoiset/dw_koodisto_relaatio.sql
@@ -1,27 +1,14 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'merge',
-    unique_key = 'koodirelaatio_id',
-    merge_exclude_columns = [
-            'dw_metadata_dbt_copied_at',
-            'dw_metadata_file_row_number',
-            'dw_metadata_filename',
-            'dw_metadata_source_timestamp_at',
-            'dw_metadata_dw_stored_at'
-            ],
+    materialized = 'table',
     indexes = [
-        {'columns': ['koodistouri']},
-        {'columns': ['muokattu']}
+        {'columns': ['koodirelaatio_id']},
     ]
     )
 }}
 
 with raw as (
     select * from {{ ref('stg_koodisto_relaatio') }}
-    {% if is_incremental() %}
-        where muokattu > (select coalesce(max(t.muokattu), date('1900-01-01')) from {{ this }} as t)
-    {% endif %}
 ),
 
 final as (
@@ -30,6 +17,5 @@ final as (
         current_timestamp as dw_metadata_dw_stored_at
     from raw
 )
-
 
 select * from final

--- a/dbt/models/int1/int1_yleiskayttoiset/int_koodisto_relaatio.sql
+++ b/dbt/models/int1/int1_yleiskayttoiset/int_koodisto_relaatio.sql
@@ -1,3 +1,12 @@
+{{
+  config(
+    indexes=[
+        {'columns':['ylakoodiarvo','ylakoodiversio']},
+        {'columns':['alakoodiarvo','alakoodiversio']},
+    ]
+    )
+}}
+
 with source as (
     select * from {{ ref('dw_koodisto_relaatio') }}
 )

--- a/dbt/models/stg/yleiskayttoiset/stg_koodisto_relaatio.sql
+++ b/dbt/models/stg/yleiskayttoiset/stg_koodisto_relaatio.sql
@@ -3,26 +3,12 @@
     materialized = 'table',
     indexes = [
         {'columns': ['koodirelaatio_id']},
-        {'columns': ['muokattu']}
     ]
     )
 }}
 
 with source as (
     select * from {{ source('ovara', 'koodisto_relaatio') }}
-{#
-    {% if is_incremental() %}
-
-        where dw_metadata_dbt_copied_at > (
-            select coalesce(max(dw_metadata_dbt_copied_at), '1899-12-31') from {{ this }}
-        )
-
-    {% endif %}
-#}
-    where
-        (data ->> 'updated')::timestamptz > (
-            select coalesce(max(muokattu), '1899-12-31') from {{ source('yleiskayttoiset', 'dw_koodisto_relaatio') }}
-        )
 
 ),
 


### PR DESCRIPTION
Korjattu logiikka niin että koodisto käsitellään aina kokonaisena eikä muutoksina